### PR TITLE
Avoid canceling timer when modifying  the regulator

### DIFF
--- a/src/raterl.erl
+++ b/src/raterl.erl
@@ -49,12 +49,10 @@ run(Name, {Type, RegulatorName}, Fun) ->
     end.
 
 info(Name) ->
-    gen_server:call(raterl_utils:queue_name(Name),
-                    info).
+    raterl_queue:info(Name).
 
 modify_regulator(Name, RegName, Limit) ->
-    gen_server:call(raterl_utils:queue_name(Name),
-                    {modify_regulator, RegName, Limit}).
+    raterl_queue:modify_regulator(Name, RegName, Limit).
 
 %%====================================================================
 %% Internal functions

--- a/src/raterl_queue.erl
+++ b/src/raterl_queue.erl
@@ -29,6 +29,10 @@
 %% API
 -export([start_link/1,
          new/1,
+         info/1,
+         modify_regulator/3,
+         cancel_timer/1,
+         restart_timer/1,
          stop/1]).
 
 %% Gen_server callbacks
@@ -40,6 +44,7 @@
          code_change/3]).
 
 -define(SERVER, ?MODULE).
+-define(REFRESH_TIMEOUT, 1000).
 
 -record(state, {
           name :: atom(),
@@ -61,6 +66,19 @@ new(Args) ->
 stop(Name) ->
     ok = gen_server:cast(raterl_utils:queue_name(Name),
                          stop).
+info(Name) ->
+    gen_server:call(raterl_utils:queue_name(Name),
+                    info).
+
+modify_regulator(Name, RegName, Limit) ->
+    gen_server:call(raterl_utils:queue_name(Name),
+                    {modify_regulator, RegName, Limit}).
+
+cancel_timer(Name) ->
+    gen_server:call(raterl_utils:queue_name(Name), cancel_timer).
+
+restart_timer(Name) ->
+    gen_server:cast(raterl_utils:queue_name(Name), restart_timer).
 
 %%====================================================================
 %% Gen_server callbacks
@@ -78,41 +96,57 @@ handle_call(info, _From, State) ->
     {reply, State, State};
 handle_call({modify_regulator, RegName, Limit}, _From,
             #state{name = Name,
-                   regulator = Regulator0,
-                   timer_ref = TimerRef0} = State0) ->
+                   regulator = Regulator0} = State0) ->
+    Table = raterl_utils:table_name(Name),
+    %% we update the counter to the new limit immediately!
+    true = ets:update_element(Table, RegName, {2, Limit}),
+
     Regulator = lists:keyreplace(limit, 1, Regulator0,
                                  {limit, Limit}),
-    Table = raterl_utils:table_name(Name),
-    %% if this is a rate regulator then we need to
-    %% cancel the refresh timer and start another with
-    %% the new limit
-    State =
-        case proplists:get_value(type, Regulator) of
-            rate ->
-                erlang:cancel_timer(TimerRef0),
-                TimerRef = erlang:send_after(1000, self(),
-                                    {refresh_rate_limit, Table, RegName, Limit + 1}),
-                State0#state{regulator = Regulator,
-                             timer_ref = TimerRef};
-            _ ->
-                State0#state{regulator = Regulator}
-        end,
-    %% in either case we update the counter to the new limit
-    true = ets:update_element(Table, RegName, {2, Limit}), 
+    State = State0#state{regulator = Regulator},
     {reply, ok, State};
+handle_call(cancel_timer, _From,
+            #state{timer_ref = TimerRef} = State)
+    when TimerRef =/= undefined ->
+    Ret = erlang:cancel_timer(TimerRef),
+    {reply, Ret, State#state{timer_ref = undefined}};
 handle_call(_Msg, _From, State) ->
-    {reply, ok, State}.
+    {reply, error, State}.
 
 handle_cast(stop, State) ->
     {stop, normal, State};
+handle_cast(restart_timer, #state{name = QueueName,
+                                  regulator = Regulator,
+                                  timer_ref = undefined} = State) ->
+    Table = raterl_utils:table_name(QueueName),
+    Name = proplists:get_value(name, Regulator),
+    TimerRef = set_refresh_timer(Table, Name),
+    {noreply, State#state{timer_ref = TimerRef}};
+handle_cast(restart_timer, #state{name = QueueName,
+                                  timer_ref = TimerRef} = State)
+    when TimerRef =/= undefined ->
+    %% first cancel the timer and then cast to self to restart it!
+    _ = erlang:cancel_timer(TimerRef),
+    restart_timer(QueueName),
+    {noreply, State#state{timer_ref = undefined}};
 handle_cast(_, State) ->
     {noreply, State}.
 
-handle_info({refresh_rate_limit, Table, Name, Limit}, State) ->
-    %% update the ets counter with the configured rate limit 
-    true = ets:update_element(Table, Name, {2, Limit}),
-    TimerRef = erlang:send_after(1000, self(),
-                                {refresh_rate_limit, Table, Name, Limit}),
+handle_info({refresh_rate_limit, Table, Name},
+            #state{regulator = Regulator} = State) ->
+    %% if this is a rate regulator then we need to
+    %% update the limit and start another timer
+    TimerRef = case proplists:get_value(type, Regulator) of
+                   rate ->
+                       %% update the ets counter with the configured rate
+                       %% to limit+1 since we'll be rate limiting at zero
+                       %% instead of at negative 1
+                       Limit = proplists:get_value(limit, Regulator),
+                       true = ets:update_element(Table, Name, {2, Limit + 1}),
+                       set_refresh_timer(Table, Name);
+                   _ ->
+                       undefined
+               end,
     {noreply, State#state{timer_ref = TimerRef}};
 handle_info(_Msg, State) ->
     {noreply, State}.
@@ -146,11 +180,7 @@ init_regulator(QueueName, rate, Name, Opts) ->
     ets:insert_new(Table, {Name, Limit + 1}),
     %% set a up a recurrent timer that sets the rate
     %% counter to the limit on every second
-    %% initialize the counter to limit+1 since
-    %% we'll be rate limiting at zero instead of
-    %% at negative 1 
-    erlang:send_after(1000, self(),
-                      {refresh_rate_limit, Table, Name, Limit + 1});
+    set_refresh_timer(Table, Name);
 init_regulator(QueueName, counter, Name, Opts) ->
     Limit = proplists:get_value(limit, Opts),
     %% create the ets counter that will hold
@@ -162,3 +192,6 @@ init_regulator(QueueName, counter, Name, Opts) ->
     ets:insert_new(Table, {Name, Limit + 1}),
     undefined.
 
+set_refresh_timer(Table, Name) ->
+    erlang:send_after(?REFRESH_TIMEOUT, self(),
+                      {refresh_rate_limit, Table, Name}).


### PR DESCRIPTION
erlang:cancel_timer doesn’t have guaranty to be able to cancel a timer
 (it can already expired!). When this happen, we may end up with 2
refresh message with different limit.