### PR TITLE
Throw exceptions resulting from the execution of work functions

### DIFF
--- a/src/raterl.erl
+++ b/src/raterl.erl
@@ -43,9 +43,11 @@ run(Name, {Type, RegulatorName}, Fun) ->
         limit_reached ->
             limit_reached;
         Ref when is_reference(Ref) ->
-            Res = (catch Fun()),
-            done(Name, {Type, RegulatorName}),
-            Res
+            try
+                Fun()
+            after
+                done(Name, {Type, RegulatorName})
+            end
     end.
 
 info(Name) ->


### PR DESCRIPTION
`catch` is very expensive as it gathers the whole stack trace. Leave it
to the caller to decide whether to catch the exception (and which of
them to catch), and also whether to collect the stack trace.