### PR TITLE
Make counter-type regulators work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: erlang
 otp_release:
   - 19.3
   - 18.3
-  - 17.5
 before_script:
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod u+x rebar3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: erlang
 otp_release:
   - 19.3
   - 18.3
+  - 20.3
+  - 21.3
+  - 22.2
 before_script:
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod u+x rebar3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Changed
+    * counter-type regulators from an ETS-centered solution to dedicated `gen_server` processes
+### Fixed
+    * unrecoverable loss of slots in counter-type regulators upon their limit being reached
+    * unrecoverable loss of slots in counter-type regulators upon slot owners being brutally killed
 
 ## [0.2.1] - 30-01-2019
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 ### Changed
     * counter-type regulators from an ETS-centered solution to dedicated `gen_server` processes
+### Removed
+    * OTP 17 support
 ### Fixed
     * unrecoverable loss of slots in counter-type regulators upon their limit being reached
     * unrecoverable loss of slots in counter-type regulators upon slot owners being brutally killed

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifeq ($(REBAR3),)
 $(error "Rebar3 not available on this system")
 endif
 
-.PHONY: all compile clean dialyzer test
+.PHONY: all compile clean dialyzer test cover
 
 all: deps compile
 travis: test
@@ -51,6 +51,9 @@ clean: $(REBAR3)
 test: compile
 	rm -rf _build/test
 	$(REBAR3) ct
+
+cover: $(REBAR3)
+	- $(REBAR3) as test ct, cover
 
 dialyzer: $(REBAR3)
 	- $(REBAR3) dialyzer

--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,3 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
+{cover_enabled, true}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, {platform_define, "^18", 'NO_MAPS_TAKE'}]}.
 {deps, []}.
 {cover_enabled, true}.

--- a/src/raterl_queue.erl
+++ b/src/raterl_queue.erl
@@ -234,13 +234,13 @@ handle_request_for_counter_slot(Pid, #state{counter_slots = CounterSlots} = Stat
     {reply, SlotRef, UpdatedState}.
 
 handle_restitution_of_counter_slot(SlotRef, #state{counter_slots = CounterSlots} = State) ->
-    {_, UpdatedCounterSlots} = maps:take(SlotRef, CounterSlots),
+    {_, UpdatedCounterSlots} = raterl_utils:maps_take(SlotRef, CounterSlots),
     demonitor(SlotRef),
     UpdatedState = State#state{counter_slots = UpdatedCounterSlots},
     {noreply, UpdatedState}.
 
 handle_monitored_process_death(Ref, #state{counter_slots = CounterSlots} = State) ->
-    case maps:take(Ref, CounterSlots) of
+    case raterl_utils:maps_take(Ref, CounterSlots) of
         {_, UpdatedCounterSlots} ->
             UpdatedState = State#state{counter_slots = UpdatedCounterSlots},
             {noreply, UpdatedState};

--- a/src/raterl_utils.erl
+++ b/src/raterl_utils.erl
@@ -26,7 +26,8 @@
 
 %% API
 -export([table_name/1,
-         queue_name/1]).
+         queue_name/1,
+         maps_take/2]).
 
 %%====================================================================
 %% API functions
@@ -38,6 +39,21 @@ table_name(Name) ->
 queue_name(Name) ->
     list_to_atom("raterl_" ++
                  atom_to_list(Name)).
+
+-ifdef(NO_MAPS_TAKE).
+maps_take(Key, Map) ->
+    try maps:get(Key, Map) of
+        Value ->
+            UpdatedMap = maps:remove(Key, Map),
+            {Value, UpdatedMap}
+    catch
+        error:{badkey, _} ->
+            error
+    end.
+-else.
+maps_take(Key, Map) ->
+    maps:take(Key, Map).
+-endif.
 
 %%====================================================================
 %% Internal functions

--- a/test/raterl_SUITE.erl
+++ b/test/raterl_SUITE.erl
@@ -76,7 +76,7 @@ end_per_testcase(_Func, Config) ->
 low_rate(doc) -> ["Low rate"];
 low_rate(suite) -> [];
 low_rate(Config) when is_list(Config) ->
-    {ok, _} = raterl_queue:new({simple_rate,
+    {ok, _} = raterl_queue:new({low_rate,
                                 [{regulator,
                                   [{name, rate},
                                    {type, rate},
@@ -84,16 +84,16 @@ low_rate(Config) when is_list(Config) ->
     %% the info request here is to ensure that
     %% the queue has been initialized before making
     %% any requests to it
-    % _ = raterl:info(simple_rate),
+    % _ = raterl:info(low_rate),
     ?assertMatch([ok,ok,ok,ok,ok],
-                 [raterl:run(simple_rate, {rate, rate}, fun() -> ok end)
+                 [raterl:run(low_rate, {rate, rate}, fun() -> ok end)
                     || _ <- lists:seq(1, 5)]),
-    ok = raterl_queue:stop(simple_rate).
+    ok = raterl_queue:stop(low_rate).
 
 close_rate(doc) -> ["Close rate"];
 close_rate(suite) -> [];
 close_rate(Config) when is_list(Config) ->
-    {ok, _} = raterl_queue:new({simple_rate,
+    {ok, _} = raterl_queue:new({close_rate,
                                 [{regulator,
                                   [{name, rate},
                                    {type, rate},
@@ -101,16 +101,16 @@ close_rate(Config) when is_list(Config) ->
     %% the info request here is to ensure that
     %% the queue has been initialized before making
     %% any requests to it
-    _ = raterl:info(simple_rate),
+    _ = raterl:info(close_rate),
     ?assertMatch([ok,ok,ok,ok,ok,ok,ok,ok,ok,ok],
-                 [raterl:run(simple_rate, {rate, rate}, fun() -> ok end)
+                 [raterl:run(close_rate, {rate, rate}, fun() -> ok end)
                     || _ <- lists:seq(1, 10)]),
-    ok = raterl_queue:stop(simple_rate).
+    ok = raterl_queue:stop(close_rate).
 
 exceeded_rate(doc) -> ["Close rate"];
 exceeded_rate(suite) -> [];
 exceeded_rate(Config) when is_list(Config) ->
-    {ok, _} = raterl_queue:new({simple_rate,
+    {ok, _} = raterl_queue:new({exceeded_rate,
                                 [{regulator,
                                   [{name, rate},
                                    {type, rate},
@@ -118,65 +118,65 @@ exceeded_rate(Config) when is_list(Config) ->
     %% the info request here is to ensure that
     %% the queue has been initialized before making
     %% any requests to it
-    _ = raterl:info(simple_rate),
+    _ = raterl:info(exceeded_rate),
     ?assertMatch([ok,ok,ok,ok,ok,ok,ok,ok,ok,ok,limit_reached],
-                 [raterl:run(simple_rate, {rate, rate}, fun() -> ok end)
+                 [raterl:run(exceeded_rate, {rate, rate}, fun() -> ok end)
                    || _ <- lists:seq(1, 11)]),
-    ok = raterl_queue:stop(simple_rate).
+    ok = raterl_queue:stop(exceeded_rate).
 
 low_count(doc) -> ["Low count"];
 low_count(suite) -> [];
 low_count(Config) when is_list(Config) ->
-    {ok, _} = raterl_queue:new({simple_counter,
+    {ok, _} = raterl_queue:new({low_counter,
                                 [{regulator,
                                   [{name, counter},
                                    {type, counter},
                                    {limit, 10}]}]}),
     try
         ?assertEqual([ok,ok,ok,ok,ok],
-                     raterl_run_nested(simple_counter, {counter, counter}, 5))
+                     raterl_run_nested(low_counter, {counter, counter}, 5))
     after
-        _ = raterl_queue:stop(simple_counter)
+        _ = raterl_queue:stop(low_counter)
     end.
 
 close_count(doc) -> ["Close count"];
 close_count(suite) -> [];
 close_count(Config) when is_list(Config) ->
-    {ok, _} = raterl_queue:new({simple_counter,
+    {ok, _} = raterl_queue:new({close_counter,
                                 [{regulator,
                                   [{name, counter},
                                    {type, counter},
                                    {limit, 10}]}]}),
     try
         ?assertEqual([ok,ok,ok,ok,ok,ok,ok,ok,ok,ok],
-                     raterl_run_nested(simple_counter, {counter, counter}, 10))
+                     raterl_run_nested(close_counter, {counter, counter}, 10))
     after
-        _ = raterl_queue:stop(simple_counter)
+        _ = raterl_queue:stop(close_counter)
     end.
 
 exceeded_count(doc) -> ["Exceeded count"];
 exceeded_count(suite) -> [];
 exceeded_count(Config) when is_list(Config) ->
-    {ok, _} = raterl_queue:new({simple_counter,
+    {ok, _} = raterl_queue:new({exceeded_counter,
                                 [{regulator,
                                   [{name, counter},
                                    {type, counter},
                                    {limit, 10}]}]}),
     try
         ?assertEqual([ok,ok,ok,ok,ok,ok,ok,ok,ok,ok,limit_reached],
-                     raterl_run_nested(simple_counter, {counter, counter}, 11)),
+                     raterl_run_nested(exceeded_counter, {counter, counter}, 11)),
         ?assertEqual([ok,ok,ok,ok,ok,ok,ok,ok,ok,ok,limit_reached],
-                     raterl_run_nested(simple_counter, {counter, counter}, 12)),
+                     raterl_run_nested(exceeded_counter, {counter, counter}, 12)),
         ?assertEqual([ok,ok,ok,ok,ok,ok,ok,ok,ok,ok,limit_reached],
-                     raterl_run_nested(simple_counter, {counter, counter}, 100))
+                     raterl_run_nested(exceeded_counter, {counter, counter}, 100))
     after
-        _ = raterl_queue:stop(simple_counter)
+        _ = raterl_queue:stop(exceeded_counter)
     end.
 
 monitored_count(doc) -> ["Monitored count"];
 monitored_count(suite) -> [];
 monitored_count(Config) when is_list(Config) ->
-    {ok, _} = raterl_queue:new({simple_counter,
+    {ok, _} = raterl_queue:new({monitored_counter,
                                 [{regulator,
                                   [{name, counter},
                                    {type, counter},
@@ -184,7 +184,7 @@ monitored_count(Config) when is_list(Config) ->
     RunGen =
         fun (UnblockKey) ->
                 fun () ->
-                        raterl:run(simple_counter, {counter, counter},
+                        raterl:run(monitored_counter, {counter, counter},
                                    fun () -> block(UnblockKey) end)
                 end
         end,
@@ -207,7 +207,7 @@ monitored_count(Config) when is_list(Config) ->
         ?assertEqual(ok, SoftRun())
     after
         _ = process_flag(trap_exit, CallerTrapExit),
-        _ = raterl_queue:stop(simple_counter)
+        _ = raterl_queue:stop(monitored_counter)
     end.
 
 queue_reconfiguration(doc) -> ["Add/remove queues in runtime"];


### PR DESCRIPTION
Move the accounting of slots to the associated `raterl_queue` processes and monitor slot owners in order to ensure that even brutally killed processes free up any slots they might have been using.

(Keep using ETS for rate-type regulators, however.)

Closes #8 .