### PR TITLE
Squash compile-time warning

### DIFF
--- a/test/raterl_SUITE.erl
+++ b/test/raterl_SUITE.erl
@@ -18,7 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 -module(raterl_SUITE).
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
I got confused with having `develop` and `master` (not used to this on GitHub). This pull request fixes the issue in `master`, though a release could also take care of it, but it's probably too much.